### PR TITLE
subscriptions implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,17 @@ The spec contains the following keys:
 ;; subscription handler
 (fsm/run
  (fsm/compile {:fsm  {::fsm/start {:handler    (fn [data]
-                                                 (assoc data :foo :bar))
+                                                 (assoc data :x {:y 1}))
                                    :dispatches [[:foo (constantly true)]]}
-                      :foo       {:handler    (fn [data] (assoc-in data [:x :y] 3))
-                                  :dispatches [[::fsm/end (constantly true)]]}}
-               :opts {:subscriptions {[:x :y] {:handler (fn [path v] (println "path" path "value" v))}}}})
- {:x {:y 1}})
-=> path [:x :y] value 3 ;; subscription handler output
-=> {:x {:y 3}, :foo :bar}
+                      :foo        {:handler    (fn [data] (update-in data [:x :y] inc))
+                                   :dispatches [[::fsm/end (constantly true)]]}}
+               :opts {:subscriptions {[:x :y] {:handler (fn [path old-value new-value] 
+                                                          (println "path" path
+                                                                   "old value" old-value 
+                                                                   "new value" new-value ))}}}}))
+=> path [:x :y] old value nil new value 1 ;; subscription handler output
+=> path [:x :y] old value 1 new value 2 ;; subscription handler output
+=> {:x {:y 2}}
 
 ;; FSM that uses an async handler
 (-> (fsm/compile

--- a/src/maestro/core.clj
+++ b/src/maestro/core.clj
@@ -107,7 +107,7 @@
          (if (= new-value value)
            (assoc m path sub)
            (do
-             (handler path new-value)
+             (handler path value new-value)
              (assoc m path (assoc sub :value new-value))))))
      {}
      subscriptions)))

--- a/test/maestro/core_test.clj
+++ b/test/maestro/core_test.clj
@@ -133,7 +133,9 @@
                           :bar       {:handler    (fn [data cb _err] (cb (update-in data [:x :y] inc)))
                                       :async?     true
                                       :dispatches [[::fsm/end (constantly true)]]}}
-                   :opts {:subscriptions {[:x :y] {:handler (fn [path v] (reset! x {path v}))}}}})
+                   :opts {:subscriptions {[:x :y] {:handler (fn [path old-value new-value] 
+                                                              (reset! x {path [old-value new-value]}))}}}})
      {:x {:y 1}})
-    (is (= @x {[:x :y] 3}))))
+    (is (= @x {[:x :y] [2 3]}))))
+
 

--- a/test/maestro/core_test.clj
+++ b/test/maestro/core_test.clj
@@ -121,3 +121,19 @@
           :ready? true})
       (is)))
 
+(deftest subscriptions-test
+  (let [x (atom nil)]
+    (fsm/run
+     (fsm/compile {:fsm  {::fsm/start {:handler    (fn [data]
+                                                     (assoc data :foo :bar))
+                                       :dispatches [[:foo (constantly true)]]}
+                          :foo       {:handler    (fn [data]
+                                                    (update-in data [:x :y] inc))
+                                      :dispatches [[:bar (constantly true)]]}
+                          :bar       {:handler    (fn [data cb _err] (cb (update-in data [:x :y] inc)))
+                                      :async?     true
+                                      :dispatches [[::fsm/end (constantly true)]]}}
+                   :opts {:subscriptions {[:x :y] {:handler (fn [path v] (reset! x {path v}))}}}})
+     {:x {:y 1}})
+    (is (= @x {[:x :y] 3}))))
+


### PR DESCRIPTION
Adds ability to register subscriptions to watch paths in the FSM state and execute side effects based on the changes in the state.