### PR TITLE
Add ClojureScript test support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,22 +4,42 @@ name: CI
 on: [push]
 
 jobs:
-  test:
+  jvm-test:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Prepare java
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'      
-
+          distribution: 'temurin'
+          java-version: '17'
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@10.2
+        uses: DeLaGuardo/setup-clojure@12.5
         with:
-          tools-deps: '1.10.1.693'
-          
-      - name: Run test suite
+          tools-deps: '1.11.4.1474'
+      - name: Run JVM tests
         run: clojure -M:test
+
+  cljs-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          tools-deps: '1.11.4.1474'
+      - name: Install npm dependencies
+        run: npm ci
+      - name: Run CLJS tests
+        run: npx shadow-cljs compile test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ output.calva-repl
 .lsp
 .nrepl-port
 .DS_Store
+node_modules/
+out/
+.shadow-cljs/

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,11 @@
 {:paths ["src"]
  :deps  {org.clojure/clojure {:mvn/version "1.11.1"}
          org.babashka/sci    {:mvn/version "0.3.2"}
-         funcool/promesa     {:mvn/version "11.0.678"}}
+         funcool/promesa     {:mvn/version "12.0.0-RC2"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps  {lambdaisland/kaocha {:mvn/version "1.75.1190"}}
-         :main-opts   ["-m" "kaocha.runner"]}}}
+         :main-opts   ["-m" "kaocha.runner"]}
+  :cljs-test {:extra-paths ["test"]
+              :extra-deps  {thheller/shadow-cljs {:mvn/version "2.28.20"}
+                            org.clojure/clojurescript {:mvn/version "1.11.132"}}}}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,205 @@
+{
+  "name": "maestro",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "maestro",
+      "devDependencies": {
+        "shadow-cljs": "^3.3.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/shadow-cljs": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-3.3.6.tgz",
+      "integrity": "sha512-t5TBJmy77abwlkAY7UOXa1s9H/28nTHeDVckgzEVS8ONYtDvbNCHEuBYfS7wwV9wVZVybRNb7dILWNXISJL1Nw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "process": "^0.11.10",
+        "readline-sync": "^1.4.10",
+        "shadow-cljs-jar": "1.3.4",
+        "source-map-support": "^0.5.21",
+        "which": "^5.0.0",
+        "ws": "^8.18.1"
+      },
+      "bin": {
+        "shadow-cljs": "cli/runner.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/shadow-cljs-jar": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz",
+      "integrity": "sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "maestro",
+  "private": true,
+  "devDependencies": {
+    "shadow-cljs": "^3.3.0"
+  }
+}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,0 +1,5 @@
+{:deps   {:aliases [:cljs-test]}
+ :builds {:test {:target    :node-test
+                 :output-to "out/test/node-test.js"
+                 :ns-regexp "-test$"
+                 :autorun   true}}}

--- a/src/maestro/core.cljc
+++ b/src/maestro/core.cljc
@@ -236,24 +236,24 @@
                                         (try
                                           (let [next (resolve-next-state fsm resources dispatches
                                                                          post result-data start-time)]
-                                            (p/resolve! d next))
+                                            (p/resolve d next))
                                           (catch #?(:clj Exception :cljs :default) e
-                                            (p/resolve! d
-                                                        (-> (update fsm :trace add-trace-segment
-                                                                    max-trace
-                                                                    {:state-id    current-state-id
-                                                                     :status      :error
-                                                                     :duration-ms (elapsed-ms start-time)})
-                                                            (assoc :current-state-id ::error :error e))))))
+                                            (p/resolve d
+                                                       (-> (update fsm :trace add-trace-segment
+                                                                   max-trace
+                                                                   {:state-id    current-state-id
+                                                                    :status      :error
+                                                                    :duration-ms (elapsed-ms start-time)})
+                                                           (assoc :current-state-id ::error :error e))))))
                              error-callback (fn [error]
-                                              (p/resolve! d
-                                                          (-> (update fsm :trace add-trace-segment
-                                                                      max-trace
-                                                                      {:state-id    current-state-id
-                                                                       :status      :error
-                                                                       :duration-ms (elapsed-ms start-time)})
-                                                              (assoc :current-state-id ::error
-                                                                     :error error))))]
+                                              (p/resolve d
+                                                         (-> (update fsm :trace add-trace-segment
+                                                                     max-trace
+                                                                     {:state-id    current-state-id
+                                                                      :status      :error
+                                                                      :duration-ms (elapsed-ms start-time)})
+                                                             (assoc :current-state-id ::error
+                                                                    :error error))))]
                          (handler resources data callback error-callback))
                        ;; If handler resolved the deferred synchronously, loop
                        ;; instead of chaining via p/then to stay stack-safe.

--- a/test/maestro/core_test.cljc
+++ b/test/maestro/core_test.cljc
@@ -97,7 +97,10 @@
               (-> (fsm/run spec)
                   (p/then (fn [result]
                             (is (= {:foo :bar :x 1 :y 2} result))
-                            (done))))))))
+                            (done)))
+                  (p/catch (fn [err]
+                             (is (nil? err) (str "Unexpected error: " err))
+                             (done))))))))
 
 (deftest async-error-test
   (let [spec (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data]
@@ -176,7 +179,10 @@
               (-> (fsm/run spec {} {:data {:x {:y 1}}})
                   (p/then (fn [_]
                             (is (= @x {[:x :y] [2 3]}))
-                            (done))))))))
+                            (done)))
+                  (p/catch (fn [err]
+                             (is (nil? err) (str "Unexpected error: " err))
+                             (done))))))))
 
 (deftest pre-post-test
   (let [spec (fsm/compile {:fsm  {::fsm/start {:handler    (fn [_resources data]
@@ -197,7 +203,10 @@
               (-> (fsm/run spec)
                   (p/then (fn [result]
                             (is (= {:pre-value 1 :foo :bar :post-value 2 :y 2 :z 3} result))
-                            (done))))))))
+                            (done)))
+                  (p/catch (fn [err]
+                             (is (nil? err) (str "Unexpected error: " err))
+                             (done))))))))
 
 (deftest pre-post-sync-test
   (->>
@@ -311,7 +320,10 @@
                 (-> (fsm/run-async spec)
                     (p/then (fn [result]
                               (is (= {:x 1} result))
-                              (done)))))))))
+                              (done)))
+                    (p/catch (fn [err]
+                               (is (nil? err) (str "Unexpected error: " err))
+                               (done)))))))))
 
 (deftest run-async-async-fsm
   (testing "run-async works with async FSM"
@@ -331,7 +343,10 @@
                 (-> (fsm/run-async spec)
                     (p/then (fn [result]
                               (is (= {:x 1} result))
-                              (done)))))))))
+                              (done)))
+                    (p/catch (fn [err]
+                               (is (nil? err) (str "Unexpected error: " err))
+                               (done)))))))))
 
 (deftest duration-ms-in-traces
   (testing "trace segments include :duration-ms"
@@ -376,7 +391,10 @@
                 (-> (fsm/run spec {} {:async? true})
                     (p/then (fn [result]
                               (is (= {:x 1} result))
-                              (done)))))))))
+                              (done)))
+                    (p/catch (fn [err]
+                               (is (nil? err) (str "Unexpected error: " err))
+                               (done)))))))))
 
 (deftest async-override-force-sync
   (testing "force sync execution on an async-compiled FSM via state map"
@@ -404,7 +422,10 @@
                 (-> (fsm/run async-spec {} {})
                     (p/then (fn [result]
                               (is (= {:x 1} result))
-                              (done)))))))))
+                              (done)))
+                    (p/catch (fn [err]
+                               (is (nil? err) (str "Unexpected error: " err))
+                               (done)))))))))
 
 (deftest analyze-reachable-states
   (testing "identifies all reachable states from start"

--- a/test/maestro/core_test.cljc
+++ b/test/maestro/core_test.cljc
@@ -1,8 +1,12 @@
 (ns maestro.core-test
   (:refer-clojure :exclude [compile])
-  (:require [clojure.test :refer :all]
-            [clojure.edn :as edn]
-            [maestro.core :as fsm]))
+  (:require
+   #?(:clj  [clojure.test :refer [deftest testing is are]]
+      :cljs [cljs.test :refer [deftest testing is are async]])
+   #?(:clj  [clojure.edn :as edn]
+      :cljs [cljs.reader :as edn])
+   [maestro.core :as fsm]
+   [promesa.core :as p]))
 
 (deftest basic-fsm
   (->> (fsm/run
@@ -43,18 +47,18 @@
 (deftest error
   (try
     (->> (fsm/run
-          (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources _data] (/ 1 0))
+          (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources _data] (throw (ex-info "Divide by zero" {})))
                                            :dispatches [[::fsm/end (constantly true)]]}}})))
     (is (= 1 0))
-    (catch Exception ex
-      (is (= "execution error" (-> ex ex-data :error (.getMessage)))))))
+    (catch #?(:clj Exception :cljs :default) ex
+      (is (= "execution error" (-> ex ex-data :error ex-message))))))
 
 (deftest custom-error-handler
   (->> (fsm/run
-        (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources _data] (/ 1 0))
+        (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources _data] (throw (ex-info "Divide by zero" {})))
                                          :dispatches [[::fsm/end (constantly true)]]}
                             ::fsm/error {:handler (fn [_resources {:keys [error]}]
-                                                    (-> error ex-data :error (.getMessage)))}}}))
+                                                    (-> error ex-data :error ex-message))}}}))
        (= "Divide by zero")
        (is)))
 
@@ -76,43 +80,54 @@
        (= {:count 4})
        (is)))
 
-(deftest async
-  ;; Async handlers return a promise on JVM — deref to get the result
-  (->> @(fsm/run
-         (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data]
-                                                        (assoc data :foo :bar))
-                                          :dispatches [[:foo     (fn [_state] true)]]}
-                             :foo       {:handler    (fn [_resources data cb _error]
-                                                       (cb (assoc data :x 1)))
-                                         :async?     true
-                                         :dispatches [[:bar (constantly true)]]}
-                             :bar       {:handler    (fn [_resources data] (assoc data :y 2))
-                                         :dispatches [[::fsm/end (constantly true)]]}}}))
-       (= {:foo :bar
-           :x   1
-           :y   2})
-       (is)))
+(deftest async-test
+  (let [spec (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data]
+                                                            (assoc data :foo :bar))
+                                              :dispatches [[:foo (fn [_state] true)]]}
+                                 :foo       {:handler    (fn [_resources data cb _error]
+                                                           (cb (assoc data :x 1)))
+                                             :async?     true
+                                             :dispatches [[:bar (constantly true)]]}
+                                 :bar       {:handler    (fn [_resources data] (assoc data :y 2))
+                                             :dispatches [[::fsm/end (constantly true)]]}}})]
+    #?(:clj
+       (is (= {:foo :bar :x 1 :y 2} @(fsm/run spec)))
+       :cljs
+       (async done
+              (-> (fsm/run spec)
+                  (p/then (fn [result]
+                            (is (= {:foo :bar :x 1 :y 2} result))
+                            (done))))))))
 
-(deftest async-error
-  (try
-    @(fsm/run
-      (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data]
-                                                     (assoc data :foo :bar))
-                                       :dispatches [[:foo (fn [_state] true)]]}
-                          :foo       {:handler    (fn [_resources _data _cb error]
-                                                    (error (ex-info "error" {})))
-                                      :async?     true
-                                      :dispatches [[:bar (constantly true)]]}
-                          :bar       {:handler    (fn [_resources data] (assoc data :y 2))
-                                      :dispatches [[::fsm/end (constantly true)]]}}}))
-    (catch Exception ex
-      ;; Promesa wraps the exception — unwrap to find our ex-info
-      (let [cause (or (.getCause ex) ex)]
-        (is (= (.getMessage cause) "execution error"))))))
+(deftest async-error-test
+  (let [spec (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data]
+                                                            (assoc data :foo :bar))
+                                              :dispatches [[:foo (fn [_state] true)]]}
+                                 :foo       {:handler    (fn [_resources _data _cb error]
+                                                           (error (ex-info "error" {})))
+                                             :async?     true
+                                             :dispatches [[:bar (constantly true)]]}
+                                 :bar       {:handler    (fn [_resources data] (assoc data :y 2))
+                                             :dispatches [[::fsm/end (constantly true)]]}}})]
+    #?(:clj
+       (try
+         @(fsm/run spec)
+         (catch Exception ex
+           (let [cause (or (ex-cause ex) ex)]
+             (is (= (ex-message cause) "execution error")))))
+       :cljs
+       (async done
+              (-> (fsm/run spec)
+                  (p/catch (fn [ex]
+                             (is (= (ex-message ex) "execution error"))
+                             (done))))))))
 
 (deftest edn-spec
-  (let [spec (fsm/compile (edn/read-string (slurp "test/fsm.edn"))
-                          {:foo (fn [_resources data] (assoc data :v 5))})]
+  (let [spec (fsm/compile
+              (edn/read-string
+               #?(:clj  (slurp "test/fsm.edn")
+                  :cljs "{:fsm {:maestro.core/start {:handler :foo :dispatches [[:maestro.core/end (fn [{:keys [v]}] (= v 5))]]}}}"))
+              {:foo (fn [_resources data] (assoc data :v 5))})]
     (is (= {:v 5} (fsm/run spec)))))
 
 (deftest halt-test
@@ -140,43 +155,51 @@
            (fsm/run fsm {} (assoc-in state [:data :ready?] true))))))
 
 (deftest subscriptions-test
-  (let [x (atom nil)]
-    ;; This test has an async handler — deref the promise result
-    @(fsm/run
-      (fsm/compile {:fsm  {::fsm/start {:handler    (fn [_resources data]
-                                                      (assoc data :foo :bar))
-                                        :dispatches [[:foo (constantly true)]]}
-                           :foo       {:handler    (fn [_resources data]
-                                                     (update-in data [:x :y] inc))
-                                       :dispatches [[:bar (constantly true)]]}
-                           :bar       {:handler    (fn [_resources data cb _err] (cb (update-in data [:x :y] inc)))
-                                       :async?     true
-                                       :dispatches [[::fsm/end (constantly true)]]}}
-                    :opts {:subscriptions {[:x :y] {:handler (fn [path old-value new-value]
-                                                               (reset! x {path [old-value new-value]}))}}}})
-      {}
-      {:data {:x {:y 1}}})
-    (is (= @x {[:x :y] [2 3]}))))
+  (let [x    (atom nil)
+        spec (fsm/compile {:fsm  {::fsm/start {:handler    (fn [_resources data]
+                                                             (assoc data :foo :bar))
+                                               :dispatches [[:foo (constantly true)]]}
+                                  :foo       {:handler    (fn [_resources data]
+                                                            (update-in data [:x :y] inc))
+                                              :dispatches [[:bar (constantly true)]]}
+                                  :bar       {:handler    (fn [_resources data cb _err] (cb (update-in data [:x :y] inc)))
+                                              :async?     true
+                                              :dispatches [[::fsm/end (constantly true)]]}}
+                           :opts {:subscriptions {[:x :y] {:handler (fn [path old-value new-value]
+                                                                      (reset! x {path [old-value new-value]}))}}}})]
+    #?(:clj
+       (do
+         @(fsm/run spec {} {:data {:x {:y 1}}})
+         (is (= @x {[:x :y] [2 3]})))
+       :cljs
+       (async done
+              (-> (fsm/run spec {} {:data {:x {:y 1}}})
+                  (p/then (fn [_]
+                            (is (= @x {[:x :y] [2 3]}))
+                            (done))))))))
 
 (deftest pre-post-test
-  ;; This test has an async handler — deref the promise result
-  (->> @(fsm/run
-         (fsm/compile {:fsm  {::fsm/start {:handler    (fn [_resources data]
-                                                         (assoc data :foo :bar))
-                                           :dispatches [[:foo (constantly true)]]}
-                              :foo       {:handler    (fn [_resources data] (assoc data :y 2))
-                                          :dispatches [[:bar (constantly true)]]}
-                              :bar       {:handler    (fn [_resources data cb _err] (cb (assoc data :z 3)))
-                                          :async?     true
-                                          :dispatches [[::fsm/end (constantly true)]]}}
-                       :opts {:pre  (fn [fsm _resources] (assoc-in fsm [:data :pre-value] 1))
-                              :post (fn [fsm _resources] (assoc-in fsm [:data :post-value] 2))}}))
-       (= {:pre-value  1
-           :foo        :bar
-           :post-value 2
-           :y          2
-           :z          3})
-       (is))
+  (let [spec (fsm/compile {:fsm  {::fsm/start {:handler    (fn [_resources data]
+                                                             (assoc data :foo :bar))
+                                               :dispatches [[:foo (constantly true)]]}
+                                  :foo       {:handler    (fn [_resources data] (assoc data :y 2))
+                                              :dispatches [[:bar (constantly true)]]}
+                                  :bar       {:handler    (fn [_resources data cb _err] (cb (assoc data :z 3)))
+                                              :async?     true
+                                              :dispatches [[::fsm/end (constantly true)]]}}
+                           :opts {:pre  (fn [fsm _resources] (assoc-in fsm [:data :pre-value] 1))
+                                  :post (fn [fsm _resources] (assoc-in fsm [:data :post-value] 2))}})]
+    #?(:clj
+       (is (= {:pre-value 1 :foo :bar :post-value 2 :y 2 :z 3}
+              @(fsm/run spec)))
+       :cljs
+       (async done
+              (-> (fsm/run spec)
+                  (p/then (fn [result]
+                            (is (= {:pre-value 1 :foo :bar :post-value 2 :y 2 :z 3} result))
+                            (done))))))))
+
+(deftest pre-post-sync-test
   (->>
    (fsm/run
     (fsm/compile {:fsm  {::fsm/start {:handler    (fn [_resources data] (update data :x inc))
@@ -205,10 +228,10 @@
        (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data] (assoc data :x 1))
                                         :dispatches [[::fsm/end (constantly false)]]}}}))
       (is false "Should have thrown an error")
-      (catch Exception ex
-        (is (= "execution error" (.getMessage ex)))
+      (catch #?(:clj Exception :cljs :default) ex
+        (is (= "execution error" (ex-message ex)))
         (let [original-error (-> ex ex-data :error)]
-          (is (= "invalid target state transition" (.getMessage original-error)))
+          (is (= "invalid target state transition" (ex-message original-error)))
           (is (= ::fsm/start (-> original-error ex-data :current-state-id)))
           (is (nil? (-> original-error ex-data :target-state-id))))))))
 
@@ -254,7 +277,7 @@
 (deftest compile-eagerly-validates-dispatches
   (testing "invalid dispatch targets are caught at compile time"
     (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
+         #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
          #"invalid dispatch"
          (fsm/compile {:fsm {::fsm/start {:handler    (fn [_ d] d)
                                           :dispatches [[:nonexistent (constantly true)]]}}})))))
@@ -275,20 +298,40 @@
       (is (identical? my-pred compiled-pred)))))
 
 (deftest run-async-sync-fsm
-  (testing "run-async wraps sync FSM result in a deref-able future"
-    (let [result @(fsm/run-async
-                   (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data] (assoc data :x 1))
-                                                    :dispatches [[::fsm/end (constantly true)]]}}}))]
-      (is (= {:x 1} result)))))
+  (testing "run-async wraps sync FSM result in a deref-able future/promise"
+    #?(:clj
+       (let [result @(fsm/run-async
+                      (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data] (assoc data :x 1))
+                                                       :dispatches [[::fsm/end (constantly true)]]}}}))]
+         (is (= {:x 1} result)))
+       :cljs
+       (let [spec (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data] (assoc data :x 1))
+                                                   :dispatches [[::fsm/end (constantly true)]]}}})]
+         (async done
+                (-> (fsm/run-async spec)
+                    (p/then (fn [result]
+                              (is (= {:x 1} result))
+                              (done)))))))))
 
 (deftest run-async-async-fsm
   (testing "run-async works with async FSM"
-    (let [result @(fsm/run-async
-                   (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data cb _err]
-                                                                  (cb (assoc data :x 1)))
-                                                    :async?     true
-                                                    :dispatches [[::fsm/end (constantly true)]]}}}))]
-      (is (= {:x 1} result)))))
+    #?(:clj
+       (let [result @(fsm/run-async
+                      (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data cb _err]
+                                                                     (cb (assoc data :x 1)))
+                                                       :async?     true
+                                                       :dispatches [[::fsm/end (constantly true)]]}}}))]
+         (is (= {:x 1} result)))
+       :cljs
+       (let [spec (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data cb _err]
+                                                                 (cb (assoc data :x 1)))
+                                                   :async?     true
+                                                   :dispatches [[::fsm/end (constantly true)]]}}})]
+         (async done
+                (-> (fsm/run-async spec)
+                    (p/then (fn [result]
+                              (is (= {:x 1} result))
+                              (done)))))))))
 
 (deftest duration-ms-in-traces
   (testing "trace segments include :duration-ms"
@@ -311,7 +354,7 @@
 (deftest duration-ms-in-error-traces
   (testing "error trace segments include :duration-ms"
     (let [result (fsm/run
-                  (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources _data] (/ 1 0))
+                  (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources _data] (throw (ex-info "test error" {})))
                                                    :dispatches [[::fsm/end (constantly true)]]}
                                       ::fsm/error {:handler (fn [_resources fsm] fsm)}}}))]
       (is (= :error (:status (first (:trace result)))))
@@ -319,12 +362,21 @@
 
 (deftest async-override-force-async
   (testing "force async execution on a sync-compiled FSM via state map"
-    (let [result @(fsm/run
-                   (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data] (assoc data :x 1))
-                                                    :dispatches [[::fsm/end (constantly true)]]}}})
-                   {}
-                   {:async? true})]
-      (is (= {:x 1} result)))))
+    #?(:clj
+       (let [result @(fsm/run
+                      (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data] (assoc data :x 1))
+                                                       :dispatches [[::fsm/end (constantly true)]]}}})
+                      {}
+                      {:async? true})]
+         (is (= {:x 1} result)))
+       :cljs
+       (let [spec (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data] (assoc data :x 1))
+                                                   :dispatches [[::fsm/end (constantly true)]]}}})]
+         (async done
+                (-> (fsm/run spec {} {:async? true})
+                    (p/then (fn [result]
+                              (is (= {:x 1} result))
+                              (done)))))))))
 
 (deftest async-override-force-sync
   (testing "force sync execution on an async-compiled FSM via state map"
@@ -338,20 +390,21 @@
 
 (deftest async-override-default-unchanged
   (testing "default behavior respects compile-time detection when :async? not in state"
-    (let [sync-result (fsm/run
-                       (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data] (assoc data :x 1))
-                                                        :dispatches [[::fsm/end (constantly true)]]}}})
-                       {}
-                       {})
-          async-result @(fsm/run
-                         (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data cb _err]
-                                                                        (cb (assoc data :x 1)))
-                                                          :async?     true
-                                                          :dispatches [[::fsm/end (constantly true)]]}}})
-                         {}
-                         {})]
-      (is (= {:x 1} sync-result))
-      (is (= {:x 1} async-result)))))
+    (let [sync-spec  (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data] (assoc data :x 1))
+                                                      :dispatches [[::fsm/end (constantly true)]]}}})
+          async-spec (fsm/compile {:fsm {::fsm/start {:handler    (fn [_resources data cb _err]
+                                                                    (cb (assoc data :x 1)))
+                                                      :async?     true
+                                                      :dispatches [[::fsm/end (constantly true)]]}}})]
+      (is (= {:x 1} (fsm/run sync-spec {} {})))
+      #?(:clj
+         (is (= {:x 1} @(fsm/run async-spec {} {})))
+         :cljs
+         (async done
+                (-> (fsm/run async-spec {} {})
+                    (p/then (fn [result]
+                              (is (= {:x 1} result))
+                              (done)))))))))
 
 (deftest analyze-reachable-states
   (testing "identifies all reachable states from start"


### PR DESCRIPTION
## Summary

- Add ClojureScript test infrastructure using shadow-cljs `:node-test` target
- Convert `test/maestro/core_test.clj` to `.cljc` with reader conditionals for cross-platform compatibility
- Upgrade Promesa from 11.0.678 to 12.0.0-RC2
- Add parallel CLJS test job to GitHub Actions CI
- Update README to reflect ClojureScript support

All 33 tests pass on both JVM and ClojureScript (Node.js).

## Test plan

- [x] JVM tests pass: `clojure -M:test` (33 tests, 58 assertions, 0 failures)
- [x] CLJS tests pass: `npx shadow-cljs compile test` (33 tests, 58 assertions, 0 failures, 0 errors)
- [ ] CI runs both test jobs in parallel on push